### PR TITLE
adding the ros2-to-ros1 bridge for ros1 code support

### DIFF
--- a/dev_ws/src/field_robot/ros_bridge/1.sh
+++ b/dev_ws/src/field_robot/ros_bridge/1.sh
@@ -1,0 +1,2 @@
+. /opt/ros/noetic/setup.bash
+roscore

--- a/dev_ws/src/field_robot/ros_bridge/2.sh
+++ b/dev_ws/src/field_robot/ros_bridge/2.sh
@@ -1,0 +1,4 @@
+. /opt/ros/noetic/setup.bash
+. /opt/ros/foxy/setup.bash
+export ROS_MASTER_URI=http://localhost:11311
+ros2 run ros1_bridge dynamic_bridge


### PR DESCRIPTION
This makes migrating the whole Hohenheim-package unnecessary and therefore, eliminates redundant work. Instead the ROS1 package can be used as it is with slight adjustments.