### PR TITLE
Integrate Docker with the main repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ hoverboard_ws/.vscode/
 hoverboard_ws/.DS_Store
 hoverboard_ws/.gitignore
 .DS_Store
+*.env

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@ Welcome to the Field Robot project!
 Please refer to the project documentation at [https://github.com/fieldrobot/field_robot/wiki](https://github.com/fieldrobot/field_robot/wiki) for all information. Guides etc. are available in German and, partly, in English.
 
 All contributors should consider [this guide](https://github.com/fieldrobot/field_robot/wiki/Nutzung-des-Repositories-(Deutsch)) on how to properly use the repository.
+
+## Docker
+For the ROS part of the Project there is a docker image and compose file. Just go to the `/dev_ws` folder and build/run the container via `docker-compose build` and `docker-compose up -d`. It should be noted that you have to use bash inside of the Container. If you want to be able to see GUIs outside of the Contianer, just add a `.env` file in the `/dev_ws` folder, defining the `DISPLAY` variable for X-Server integration.

--- a/dev_ws/Dockerfile
+++ b/dev_ws/Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:focal
+
+#CUSTOM
+ARG DEBIAN_FRONTEND=noninteractive
+
+#locale - timezone setup
+RUN apt update && \
+  apt install -y locales && \
+  locale-gen en_US en_US.UTF-8 && \
+  update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+#setup sources
+RUN apt update && \
+  apt install -y curl gnupg2 lsb-release && \
+  curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+#install ROS
+ENV ROS_DISTRO foxy
+RUN apt update && apt install -y ros-foxy-ros-base && \
+  echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc && \
+  echo "source /field_robot/dev_ws/install/setup.bash" >> ~/.bashrc
+
+#additional recommended/necessary packages
+RUN apt update && apt install -y \
+  build-essential \ 
+  ros-foxy-rviz2 \
+  python3-colcon-common-extensions \
+  python3-colcon-mixin \
+  python3-rosdep \
+  python3-vcstool \
+  python3-argcomplete
+
+# Finalise ROS setup
+RUN rosdep init && rosdep update --rosdistro $ROS_DISTRO
+
+# Project Dependencys
+RUN apt update && apt install -y \
+  ros-foxy-navigation2 \
+  ros-foxy-nav2-bringup \
+  ros-foxy-slam-toolbox \
+  ros-foxy-behaviortree-cpp-v3 \
+  ros-foxy-cv-bridge \
+  ros-foxy-robot-localization \
+  python3-opencv\
+  dos2unix
+
+# Install Gazebo
+RUN apt update && apt install -y ros-foxy-gazebo-ros-pkgs
+
+# Install Pip (And possible Pip dependencys)
+RUN apt update && apt install -y python3-pip && \
+  pip install --upgrade pip && \
+  pip install tensorflow-aarch64 -f https://tf.kmtea.eu/whl/stable.html
+
+RUN apt update && apt upgrade -y
+
+#volumes for field_robot folder
+VOLUME [ "/field_robot" ]
+
+CMD bash

--- a/dev_ws/docker-compose.yml
+++ b/dev_ws/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+# Don't forget to add a .env File defining the 'DISPLAY' Variable (see wiki for more Info)
+services:      
+  field_robot:
+    container_name: field_robot
+    image: field_robot
+    env_file:
+      - .env
+    build:
+      context: .
+    volumes:
+      - .:/field_robot
+    tty: true


### PR DESCRIPTION
Before, the Docker image was in another repository and you had to build and run the Image via rather long commands manually. Now, the Image is contained in the same Repository and you can build and run it quickly via `docker-compose`, which should make it easier to start developing.

The only adjustment users of the Image have to make is to add a `.env` file, containing the `DISPLAY` variable used for X-Server integration, i.e. displaying GUIs outside of the container.

Also, I added a section to the `README.md` containing all information needed to run the ROS part of the project in Docker, so it is one of the first things you see when engaging with the project.